### PR TITLE
ENH: .bvals and .bval can be loaded as well as .bvecs and .bvec

### DIFF
--- a/dtiplayground/config.py
+++ b/dtiplayground/config.py
@@ -1,10 +1,10 @@
 
 INFO = {
   "dtiplayground": { 
-    "version" : "0.3.0-beta6"
+    "version" : "0.3.2-beta1"
   },
   "dmriprep": {
-    "version" : "0.3.0-beta6"
+    "version" : "0.3.2-beta1"
   },
   "dtiatlasbuilder": {
     "version" : "0.1.0"

--- a/dtiplayground/dmri/preprocessing/dwi.py
+++ b/dtiplayground/dmri/preprocessing/dwi.py
@@ -114,8 +114,13 @@ def _load_nifti_bvecs(filename):
 
 def _load_nifti(filename,bvecs_file=None,bvals_file=None):
     parent_dir=Path(filename).parent
-    if bvals_file is None: bvals_file=parent_dir.joinpath(Path(Path(filename).stem).stem+'.bvals')
-    if bvecs_file is None: bvecs_file=parent_dir.joinpath(Path(Path(filename).stem).stem+'.bvecs')
+    if bvals_file is None: bvals_file=parent_dir.joinpath(Path(Path(filename).stem).stem+'.bval')
+    if bvecs_file is None: bvecs_file=parent_dir.joinpath(Path(Path(filename).stem).stem+'.bvec')
+
+    if not bvals_file.exists():
+        bvals_file=parent_dir.joinpath(Path(Path(filename).stem).stem+'.bvals')
+    if not bvecs_file.exists():
+        bvecs_file=parent_dir.joinpath(Path(Path(filename).stem).stem+'.bvecs')
     
     loaded_image_object= nib.load(filename)
     header=loaded_image_object.header
@@ -301,8 +306,8 @@ def _write_nifti(image,filename,dtype): #image : DWI
     data,affine,bvals,bvecs=export_to_nifti(image)
     out_dir=Path(filename).parent
     filename_stem=Path(filename).name.split('.')[0]
-    bvals_filename=out_dir.joinpath(filename_stem+".bvals")
-    bvecs_filename=out_dir.joinpath(filename_stem+".bvecs")
+    bvals_filename=out_dir.joinpath(filename_stem+".bval")
+    bvecs_filename=out_dir.joinpath(filename_stem+".bvec")
     data=data.astype(dtype)
     out_image_object=nib.Nifti1Image(data,affine)
     nib.save(out_image_object,str(filename))

--- a/dtiplayground/dmri/preprocessing/modules/EDDYMOTION_Correct/EDDYMOTION_Correct.py
+++ b/dtiplayground/dmri/preprocessing/modules/EDDYMOTION_Correct/EDDYMOTION_Correct.py
@@ -110,27 +110,29 @@ class EDDYMOTION_Correct(prep.modules.DTIPrepModule):
 
         ### conversion to nifti 
         input_nifti=output_dir.joinpath('input.nii.gz').__str__()
-        input_bvals=output_dir.joinpath('input.bvals').__str__()
-        input_bvecs=output_dir.joinpath('input.bvecs').__str__()
+        input_bvals=output_dir.joinpath('input.bval').__str__()
+        input_bvecs=output_dir.joinpath('input.bvec').__str__()
         output_nifti=output_dir.joinpath('output.nii.gz').__str__()
         binary_mask=output_dir.joinpath('output_mask.nii.gz').__str__()
         processed_nifti=output_dir.joinpath('output_eddied.nii.gz').__str__()
         processed_nifti_base=Path(processed_nifti).parent.joinpath(Path(processed_nifti).name.split('.')[0]).__str__()
         processed_nifti_nonneg=output_dir.joinpath('output_eddied_nonneg.nii.gz').__str__()
-        processed_bvals=output_dir.joinpath('output_eddied.bvals').__str__()
-        processed_bvecs=output_dir.joinpath('output_eddied.bvecs').__str__()
+        processed_bvals=output_dir.joinpath('output_eddied.bval').__str__()
+        processed_bvecs=output_dir.joinpath('output_eddied.bvec').__str__()
         output_nrrd=output_dir.joinpath('output.nrrd').__str__()
         quad_output_dir=output_dir.joinpath('output_eddied.qc').__str__()
-        
+        _average_path=output_dir.joinpath("_average.nii.gz").__str__()
+
         self.writeImage(str(input_nifti),dest_type='nifti')
         img=self.loadImage(input_nifti)
-        img.writeImage(Path(output_dir.joinpath("input_dev.nrrd")).__str__(),dest_type='nrrd')
 
         ### generate mask
         fsl=tools.FSL(self.software_info['FSL']['path'])
         fsl._set_num_threads(self.num_threads)
         fsl.setDevMode(True)
         logger("Generating Mask : {}".format(binary_mask.__str__()))
+
+        output=fsl.fslmaths_ops(input_nifti,_average_path,'mean')
         res=fsl.bet(str(input_nifti),str(output_nifti))
         ouput_nifti=Path(output_nifti).rename(output_dir.joinpath('temp.nii.gz').__str__())
 
@@ -161,8 +163,8 @@ class EDDYMOTION_Correct(prep.modules.DTIPrepModule):
 
         logger("Generating Non negative DWI...to {}".format(str(processed_nifti_nonneg)),prep.Color.PROCESS)
         nonneg_base=Path(processed_nifti_nonneg).name.split('.')[0]
-        processed_nifti_nonneg_bvals=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bvals").__str__()
-        processed_nifti_nonneg_bvecs=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bvecs").__str__()
+        processed_nifti_nonneg_bvals=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bval").__str__()
+        processed_nifti_nonneg_bvecs=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bvec").__str__()
 
         if not Path(processed_nifti_nonneg).exists():
             output=fsl.fslmaths_threshold(processed_nifti,processed_nifti_nonneg,0)
@@ -202,8 +204,8 @@ class EDDYMOTION_Correct(prep.modules.DTIPrepModule):
         processed_nifti=output_dir.joinpath('output_eddied.nii.gz').__str__()
         processed_nifti_base=Path(processed_nifti).parent.joinpath(Path(processed_nifti).name.split('.')[0]).__str__()
         processed_nifti_nonneg=output_dir.joinpath('output_eddied_nonneg.nii.gz').__str__()
-        processed_bvals=output_dir.joinpath('output_eddied.bvals').__str__()
-        processed_bvecs=output_dir.joinpath('output_eddied.bvecs').__str__()
+        processed_bvals=output_dir.joinpath('output_eddied.bval').__str__()
+        processed_bvecs=output_dir.joinpath('output_eddied.bvec').__str__()
         output_nrrd=output_dir.joinpath('output.nrrd').__str__()
         quad_output_dir=output_dir.joinpath('output_eddied.qc').__str__()
 
@@ -243,8 +245,8 @@ class EDDYMOTION_Correct(prep.modules.DTIPrepModule):
 
         logger("Generating Non negative DWI...",prep.Color.PROCESS)
         nonneg_base=Path(processed_nifti_nonneg).name.split('.')[0]
-        processed_nifti_nonneg_bvals=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bvals").__str__()
-        processed_nifti_nonneg_bvecs=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bvecs").__str__()
+        processed_nifti_nonneg_bvals=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bval").__str__()
+        processed_nifti_nonneg_bvecs=Path(processed_nifti_nonneg).parent.joinpath(nonneg_base+".bvec").__str__()
 
         if not Path(processed_nifti_nonneg).exists():
             output=fsl.fslmaths_threshold(processed_nifti,processed_nifti_nonneg,0)

--- a/dtiplayground/dmri/preprocessing/modules/SUSCEPTIBILITY_Correct/SUSCEPTIBILITY_Correct.py
+++ b/dtiplayground/dmri/preprocessing/modules/SUSCEPTIBILITY_Correct/SUSCEPTIBILITY_Correct.py
@@ -148,13 +148,13 @@ class SUSCEPTIBILITY_Correct(prep.modules.DTIPrepModule):
         
         output=fsl.fslmerge(outputfilename,pe_files)
         ## making merged bvals,bvecs
-        bvals_fn=Path(self.output_dir).joinpath(Path(outputfilename).name.split('.')[0]+'.bvals')
-        bvecs_fn=Path(self.output_dir).joinpath(Path(outputfilename).name.split('.')[0]+'.bvecs')
+        bvals_fn=Path(self.output_dir).joinpath(Path(outputfilename).name.split('.')[0]+'.bval')
+        bvecs_fn=Path(self.output_dir).joinpath(Path(outputfilename).name.split('.')[0]+'.bvec')
 
-        input_bvals_fn_0=Path(self.output_dir).joinpath(Path(pe_files[0]).name.split('.')[0]+'.bvals')
-        input_bvecs_fn_0=Path(self.output_dir).joinpath(Path(pe_files[0]).name.split('.')[0]+'.bvecs')
-        input_bvals_fn_1=Path(self.output_dir).joinpath(Path(pe_files[1]).name.split('.')[0]+'.bvals')
-        input_bvecs_fn_1=Path(self.output_dir).joinpath(Path(pe_files[1]).name.split('.')[0]+'.bvecs')
+        input_bvals_fn_0=Path(self.output_dir).joinpath(Path(pe_files[0]).name.split('.')[0]+'.bval')
+        input_bvecs_fn_0=Path(self.output_dir).joinpath(Path(pe_files[0]).name.split('.')[0]+'.bvec')
+        input_bvals_fn_1=Path(self.output_dir).joinpath(Path(pe_files[1]).name.split('.')[0]+'.bval')
+        input_bvecs_fn_1=Path(self.output_dir).joinpath(Path(pe_files[1]).name.split('.')[0]+'.bvec')
         
         with open(bvals_fn,'w') as fw:
             bvals1=open(input_bvals_fn_0,'r').read()
@@ -259,8 +259,8 @@ class SUSCEPTIBILITY_Correct(prep.modules.DTIPrepModule):
 
         logger("Merging original images ... ",prep.Color.PROCESS)
         merged_image_filename=Path(self.output_dir).joinpath("merged_image.nii.gz").__str__()
-        merged_bvals_filename=Path(self.output_dir).joinpath("merged_image.bvals").__str__()
-        merged_bvecs_filename=Path(self.output_dir).joinpath("merged_image.bvecs").__str__()
+        merged_bvals_filename=Path(self.output_dir).joinpath("merged_image.bval").__str__()
+        merged_bvecs_filename=Path(self.output_dir).joinpath("merged_image.bvec").__str__()
         self.merge_images(merged_image_filename,pe_files,b0_threshold)
 
         ## load merged image into self.image 

--- a/dtiplayground/dmri/preprocessing/protocols.py
+++ b/dtiplayground/dmri/preprocessing/protocols.py
@@ -79,7 +79,7 @@ def _generate_output_directories_mapping(output_dir,exec_sequence): ## map exec 
         options=execution['options']
         image_path=execution['image_path']
         order=execution['order']
-        module_output_dir=Path(output_dir).joinpath(Path(image_path).stem).joinpath("{:02d}_{}".format(order,m))
+        module_output_dir=Path(output_dir).joinpath(Path(image_path).stem.split('.')[0]).joinpath("{:02d}_{}".format(order,m))
         #module_output_dir.mkdir(parents=True,exist_ok=True)
         module_output_dirs[uid]=str(module_output_dir)
     return module_output_dirs
@@ -141,7 +141,7 @@ class Protocols:
             img.getGradients()
             self.images.append(img)
         self.original_image_information = self.images[0].information
-        self.oriiginal_image_format = self.images[0].image_type
+        self.original_image_format = self.images[0].image_type
 
     def setOutputDirectory(self, output_dir=None):
         if output_dir is None:


### PR DESCRIPTION
.bval .bvec extension for nifti can be loaded 
default extension for nifti changed from bvals/bvecs to bval/bvec
